### PR TITLE
Compile empty Haskell strings to empty C strings rather than NULL

### DIFF
--- a/ivory/src/Ivory/Language/IString.hs
+++ b/ivory/src/Ivory/Language/IString.hs
@@ -19,6 +19,4 @@ instance IvoryExpr IString where
   wrapExpr = IString
 
 instance IsString IString where
-  fromString str = wrapExpr $ AST.ExpLit $ case str of
-    [] -> AST.LitNull
-    _  -> AST.LitString str
+  fromString str = wrapExpr $ AST.ExpLit $ AST.LitString str


### PR DESCRIPTION
Right now Ivory compiles the empty Haskell string "" to NULL rather than to "". This can cause inadvertent seg faults.
