### PR TITLE
Added inclusive boolean for LoopIncr constructors, fixed for and times

### DIFF
--- a/ivory-backend-c/src/Ivory/Compile/C/Gen.hs
+++ b/ivory-backend-c/src/Ivory/Compile/C/Gen.hs
@@ -313,11 +313,17 @@ toBody ens stmt =
       ty = I.ixRep
       (test,incExp)  = toIncr incr
       ix = toVar var
-      toIncr (I.IncrTo to) =
+      toIncr (I.IncrTo True to) =
         ( [cexp| $id:ix <= $exp:(toExpr ty to) |]
         , [cexp| $id:ix++ |] )
-      toIncr (I.DecrTo to) =
+      toIncr (I.IncrTo False to) =
+        ( [cexp| $id:ix < $exp:(toExpr ty to) |]
+        , [cexp| $id:ix++ |] )
+      toIncr (I.DecrTo True to) =
         ( [cexp| $id:ix >= $exp:(toExpr ty to) |]
+        , [cexp| $id:ix-- |] )
+      toIncr (I.DecrTo False to) =
+        ( [cexp| $id:ix > $exp:(toExpr ty to) |]
         , [cexp| $id:ix-- |] )
 
     I.Forever blk ->

--- a/ivory-opts/src/Ivory/Opts/AssertFold.hs
+++ b/ivory-opts/src/Ivory/Opts/AssertFold.hs
@@ -148,8 +148,8 @@ stmtFold ef stmt = case stmt of
   where
   efTyped (I.Typed ty e) = ef ty e
   efIncr incr = case incr of
-    I.IncrTo e -> ef ty e
-    I.DecrTo e -> ef ty e
+    I.IncrTo b e -> ef ty e
+    I.DecrTo b e -> ef ty e
     where ty = I.ixRep
   efInit init' = case init' of
     I.InitZero          -> return ()

--- a/ivory-opts/src/Ivory/Opts/CSE.hs
+++ b/ivory-opts/src/Ivory/Opts/CSE.hs
@@ -147,8 +147,8 @@ data BlockF t
   deriving (Show, Eq, Ord, Functor)
 
 data LoopIncrF t
-  = IncrTo t
-  | DecrTo t
+  = IncrTo Bool t
+  | DecrTo Bool t
   deriving (Show, Eq, Ord, Functor)
 
 data InitF t
@@ -184,8 +184,8 @@ instance MuRef AST.Stmt where
     mapInit (AST.InitExpr ty ex) = InitExpr ty <$> child ex
     mapInit (AST.InitStruct fields) = InitStruct <$> traverse (\ (nm, i) -> (,) nm <$> mapInit i) fields
     mapInit (AST.InitArray elements) = InitArray <$> traverse mapInit elements
-    mapIncr (AST.IncrTo ex) = IncrTo <$> child ex
-    mapIncr (AST.DecrTo ex) = DecrTo <$> child ex
+    mapIncr (AST.IncrTo b ex) = IncrTo b <$> child ex
+    mapIncr (AST.DecrTo b ex) = DecrTo b <$> child ex
 
 instance (MuRef a, DeRef [a] ~ DeRef a) => MuRef [a] where
   type DeRef [a] = CSE
@@ -219,8 +219,8 @@ toBlock expr block b = case b of
   toInit (InitExpr ty ex) = AST.InitExpr ty <$> expr ex ty
   toInit (InitStruct fields) = AST.InitStruct <$> traverse (\ (nm, i) -> (,) nm <$> toInit i) fields
   toInit (InitArray elements) = AST.InitArray <$> traverse toInit elements
-  toIncr (IncrTo ex) = AST.IncrTo <$> expr ex ixRep
-  toIncr (DecrTo ex) = AST.DecrTo <$> expr ex ixRep
+  toIncr (IncrTo b ex) = AST.IncrTo b <$> expr ex ixRep
+  toIncr (DecrTo b ex) = AST.DecrTo b <$> expr ex ixRep
 
 -- | When a statement contains a block, we need to propagate the
 -- available expressions into that block. However, on exit from that

--- a/ivory-opts/src/Ivory/Opts/ConstFold.hs
+++ b/ivory-opts/src/Ivory/Opts/ConstFold.hs
@@ -176,8 +176,8 @@ cf copies ty e =
 loopIncrFold :: (I.Expr -> I.Expr) -> I.LoopIncr -> I.LoopIncr
 loopIncrFold opt incr =
   case incr of
-    I.IncrTo e0 -> I.IncrTo (opt e0)
-    I.DecrTo e0 -> I.DecrTo (opt e0)
+    I.IncrTo b e0 -> I.IncrTo b (opt e0)
+    I.DecrTo b e0 -> I.DecrTo b (opt e0)
 
 --------------------------------------------------------------------------------
 

--- a/ivory/src/Ivory/Language/Coroutine.hs
+++ b/ivory/src/Ivory/Language/Coroutine.hs
@@ -171,9 +171,9 @@ extractLocals next (AST.Loop var initEx incr b : rest) = do
   after <- makeLabel $ extractLocals next rest
   loop <- mfix $ \ loop -> makeLabel $ do
     let (condOp, incOp, limitEx) = case incr of
-          AST.IncrTo ex -> (AST.ExpGt, AST.ExpAdd, ex)
-          AST.DecrTo ex -> (AST.ExpLt, AST.ExpSub, ex)
-    cond <- updateExpr $ AST.ExpOp (condOp False ty) [AST.ExpVar var, limitEx]
+          AST.IncrTo b ex -> (AST.ExpGt b, AST.ExpAdd, ex)
+          AST.DecrTo b ex -> (AST.ExpLt b, AST.ExpSub, ex)
+    cond <- updateExpr $ AST.ExpOp (condOp ty) [AST.ExpVar var, limitEx]
     CondBranchTo cond <$> getBlock [] (goto after) <*> do
       setBreakLabel after $ getBlock b $ do
         stmt $ AST.Store ty cont $ AST.ExpOp incOp [AST.ExpVar var, AST.ExpLit (AST.LitInteger 1)]

--- a/ivory/src/Ivory/Language/Loop.hs
+++ b/ivory/src/Ivory/Language/Loop.hs
@@ -3,8 +3,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Ivory.Language.Loop where
+
 
 import Ivory.Language.IIntegral
 import Ivory.Language.IBool
@@ -45,11 +47,11 @@ loop incr fromIdx toIdx body = do
 
 upTo :: ANat n
      => Ix n -> Ix n -> (Ix n -> Ivory (E.AllowBreak eff) a) -> Ivory eff ()
-upTo = loop AST.IncrTo
+upTo = loop (AST.IncrTo False)
 
 downTo :: ANat n
        => Ix n -> Ix n -> (Ix n -> Ivory (E.AllowBreak eff) a) -> Ivory eff ()
-downTo = loop AST.DecrTo
+downTo = loop (AST.DecrTo False)
 
 -- | Run the computation n times, where
 -- @
@@ -58,7 +60,7 @@ downTo = loop AST.DecrTo
 -- Indexes increment from 0 to n-1 incluseively.
 for :: forall eff n a. ANat n
     => Ix n -> (Ix n -> Ivory (E.AllowBreak eff) a) -> Ivory eff ()
-for n f = upTo 0 (n-1) f
+for n f = upTo 0 n f
 
 -- | Run the computation n times, where
 -- @
@@ -67,13 +69,13 @@ for n f = upTo 0 (n-1) f
 -- Indexes decrement from n-1 to 0 inclusively.
 times :: forall eff n a. ANat n
       => Ix n -> (Ix n -> Ivory (E.AllowBreak eff) a) -> Ivory eff ()
-times n f = downTo (n-1) 0 f
+times n f = downTo n 0 $ f . \x -> x - 1
 
 arrayMap :: forall eff n a . ANat n
          => (Ix n -> Ivory (E.AllowBreak eff) a) -> Ivory eff ()
 arrayMap = upTo 0 hi
   where
-  hi = fromInteger ((fromTypeNat (aNat :: NatType n)) - 1)
+  hi = fromInteger ((fromTypeNat (aNat :: NatType n)))
 
 forever :: Ivory (E.AllowBreak eff) () -> Ivory eff ()
 forever body = do

--- a/ivory/src/Ivory/Language/Syntax/AST.hs
+++ b/ivory/src/Ivory/Language/Syntax/AST.hs
@@ -214,9 +214,10 @@ data Stmt
     -- ^ User comment, can be used to output a comment in the backend.
     deriving (Show, Eq, Ord)
 
+-- Bool argument determines inclusivity, analagous to ExpGt and ExpLt's args
 data LoopIncr
-  = IncrTo Expr
-  | DecrTo Expr
+  = IncrTo Bool Expr
+  | DecrTo Bool Expr
     deriving (Show, Eq, Ord)
 
 data Name


### PR DESCRIPTION
Here's a fix for `for 0` and `times 0` that adds an boolean argument to the `LoopIncr` constructors which determines if they are inclusive of their end value.