### PR TITLE
Standalone ivory compiler 'ic'

### DIFF
--- a/ivory-backend-c/example/fib.hs
+++ b/ivory-backend-c/example/fib.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Fib where
+import Ivory.Language
+import Ivory.Artifact
+import qualified Ivory.Compile.C.CmdlineFrontend as C (compile)
+
+fib_loop :: Def ('[Ix 1000] :-> Uint32)
+fib_loop  = proc "fib_loop" $ \ n -> body $ do
+  a <- local (ival 0)
+  b <- local (ival 1)
+
+  n `times` \ _ -> do
+    a' <- deref a
+    b' <- deref b
+    store a b'
+    store b (a' + b')
+
+  result <- deref a
+  ret result
+
+fib_tutorial_module :: Module
+fib_tutorial_module = package "fib_tutorial" $ do
+  incl fib_loop
+
+main :: ([Module], [Artifact])
+main = ([ fib_tutorial_module ], [])

--- a/ivory-backend-c/example/fib.hs
+++ b/ivory-backend-c/example/fib.hs
@@ -1,10 +1,23 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
+
+--------------------------------------------------------------------------------
+--  Example Use
+--------------------------------------------------------------------------------
+-- From the 'ivory' top level directory:
+--
+-- make
+-- cabal exec ic -- -o /tmp/fib_module_files ./ivory-backend-c/examples/fib.c
+--
+-- Notice 'cabal exec' allows 'ic' to find the shared Haskell libraries in
+-- the proper sandbox so you don't have to statically link the binary or install
+-- the libraries at a user or global level.
+
+
 module Fib where
 import Ivory.Language
 import Ivory.Artifact
-import qualified Ivory.Compile.C.CmdlineFrontend as C (compile)
 
 fib_loop :: Def ('[Ix 1000] :-> Uint32)
 fib_loop  = proc "fib_loop" $ \ n -> body $ do

--- a/ivory-backend-c/ic/Main.hs
+++ b/ivory-backend-c/ic/Main.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+import Ivory.Compile.C.CmdlineFrontend (runCompiler, Opts(..), initialOpts)
+import Ivory.Language (Module)
+import Ivory.Artifact (Artifact)
+import Language.Haskell.Interpreter
+import Language.Haskell.Interpreter.Unsafe
+import System.Console.GetOpt.Simple
+import System.FilePath
+import Data.Char
+import Data.List (intersperse)
+import Data.Typeable
+
+import qualified Data.Map as M
+
+deriving instance Typeable Module
+deriving instance Typeable Artifact
+
+icCfg :: Conf
+icCfg = [ (arg, "output", Optional, "Output file name")
+      , (arg, "input",  Optional, "Input file name")
+      ]
+
+pkgDb :: M.Map String String -> Maybe String
+pkgDb = M.lookup "pkg-db"
+
+main :: IO ()
+main = do
+    (opts0, iptMb) <- getUsingConf icCfg ["input"]
+    let opts = M.insert "input" ipt opts0
+        ipt  = head iptMb
+        iopt = initialOpts { outDir  = M.lookup "ouput" opts }
+
+    (ivoryModules, ivoryArtifacts) <- interpFile ipt (pkgDb opts)
+    runCompiler ivoryModules ivoryArtifacts iopt
+
+interpFile :: FilePath -> Maybe FilePath -> IO ([Module], [Artifact])
+interpFile file db =
+  do res <- interp
+     case res of
+         Left err -> error $ renderError err
+         Right prog -> return prog
+ where
+    customInterp = case db of
+                        Nothing -> runInterpreter
+                        Just fp ->
+                            unsafeRunInterpreterWithArgs [ "-no-user-package-db"
+                                                         , "package-db " ++ fp
+                                                         ]
+    fileModule = let (s:str) = dropExtension $ takeBaseName file
+                 in map (\x -> if x == '-' then '_' else x) (toUpper s : str)
+    interp = customInterp $ do
+        loadModules [file]
+        setImportsQ [ ( fileModule, Nothing )
+                    , ( "Ivory.Language", Nothing)
+                    , ( "Ivory.Artifact", Nothing)
+                    , ( "Ivory.Compile.C.CmdlineFrontend", Nothing) ]
+        interpret "main" infer
+
+renderError :: InterpreterError -> String
+renderError x =
+ case x of
+  UnknownError msg -> msg
+  WontCompile errs -> concat . intersperse "\n\n" . map errMsg $ errs
+  NotAllowed   msg -> msg
+  GhcException msg -> msg

--- a/ivory-backend-c/ic/Main.hs
+++ b/ivory-backend-c/ic/Main.hs
@@ -19,8 +19,8 @@ deriving instance Typeable Artifact
 
 icCfg :: Conf
 icCfg = [ (arg, "output", Optional, "Output file name")
-      , (arg, "input",  Optional, "Input file name")
-      ]
+        , (arg, "input",  Optional, "Input file name")
+        ]
 
 pkgDb :: M.Map String String -> Maybe String
 pkgDb = M.lookup "pkg-db"
@@ -30,7 +30,7 @@ main = do
     (opts0, iptMb) <- getUsingConf icCfg ["input"]
     let opts = M.insert "input" ipt opts0
         ipt  = head iptMb
-        iopt = initialOpts { outDir  = M.lookup "ouput" opts }
+        iopt = initialOpts { outDir  = M.lookup "output" opts }
 
     (ivoryModules, ivoryArtifacts) <- interpFile ipt (pkgDb opts)
     runCompiler ivoryModules ivoryArtifacts iopt

--- a/ivory-backend-c/ivory-backend-c.cabal
+++ b/ivory-backend-c/ivory-backend-c.cabal
@@ -49,3 +49,11 @@ library
   default-language:     Haskell2010
 
   ghc-options:          -Wall
+
+executable ic
+    buildable:          True
+    build-depends:      base, hint, containers, ivory-backend-c, getopt-simple, filepath, ivory, ivory-backend-c, ivory-artifact
+    main-is:             Main.hs
+    hs-source-dirs:     ic
+    default-language:   Haskell2010
+    ghc-options:       -Wall -rtsopts


### PR DESCRIPTION
The 'ic' compiler uses hint in the common way to produce an AST leaving
the actual compilation to be done by the (non-interpreted) machine code.

I've used this strategy previously, along with `cabal exec` to use sandboxed libraries, in Ninjas and ShareMonad with reasonable success.  Not sure if it is fitting for the Ivory setting, discussion is welcome.