### PR TITLE
Changed the outDir to Nothing instead of Just ""

### DIFF
--- a/ivory-backend-c/src/Ivory/Compile/C/CmdlineFrontend/Options.hs
+++ b/ivory-backend-c/src/Ivory/Compile/C/CmdlineFrontend/Options.hs
@@ -77,7 +77,7 @@ data Opts = Opts
 
 initialOpts :: Opts
 initialOpts  = Opts
-  { outDir       = Just ""
+  { outDir       = Nothing
   , outHdrDir    = Nothing
   , outArtDir    = Nothing
 


### PR DESCRIPTION
Now it will check the default value in tower-aadl/src/Tower/AADL.hs instead of just crashing.