### PR TITLE
track last-seen occurrence of Vars separately

### DIFF
--- a/ivory-model-check/src/Ivory/ModelCheck/Monad.hs
+++ b/ivory-model-check/src/Ivory/ModelCheck/Monad.hs
@@ -245,7 +245,6 @@ withLocalRefs :: ModelCheck a -> ModelCheck a
 withLocalRefs m = do
   st <- get
   let refs = symRefs st
-  let env  = symEnv st
   -- sets_ (\s -> s { symRefs = mempty })
   a <- m
   sets_ (\s -> s { symRefs = refs })

--- a/ivory-model-check/test/Test.hs
+++ b/ivory-model-check/test/Test.hs
@@ -25,6 +25,7 @@ import qualified Examples
 import qualified Heartbeat
 import qualified PPM
 import qualified RingBuffer
+import qualified Tutorial
 
 main :: IO ()
 main = defaultMain tests
@@ -56,6 +57,8 @@ shouldPass = testGroup "should be safe" $
                [ PPM.ppmModule ]
              , mkSuccessInline RingBuffer.push_pop_inv
                [ RingBuffer.testModule ]
+             , mkSuccessInline Tutorial.check_potion_use
+               [ Tutorial.mypackage ]
              ] ++
              -- FIXME: this test emits incorrectly typed CVC4.
              if True then [] else

--- a/ivory-model-check/test/Tutorial.hs
+++ b/ivory-model-check/test/Tutorial.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeOperators #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Tutorial where
+
+import Ivory.Language
+import Ivory.Language.Cond
+
+[ivory|
+
+struct Character
+  { hp     :: Stored Uint16
+  ; max_hp :: Stored Uint16
+  ; mp     :: Stored Uint16
+  ; max_mp :: Stored Uint16
+  ; potions:: Stored Uint8
+  }
+
+void use_potion(*struct Character c) {
+  let ps = *c.potions;
+  assume ps > 0;
+
+  if (ps > 0) {
+    -- decrement the number of available potions
+    store c.potions as (ps - 1);
+
+    -- increase mp up to the maximum
+    let mp_val = *c.mp;
+    let mp_max = *c.max_mp;
+    if ((mp_val + 25) < mp_max) {
+      store c.mp as (mp_val + 25);
+    } else {
+      store c.mp as mp_max;
+    }
+  } else {}
+  let ps' = *c.potions;
+  assert ps > ps';
+}
+|]
+
+mypackage :: Module
+mypackage = package "mypackage" $ do
+  defStruct (Proxy :: Proxy "Character")
+  incl use_potion
+
+potions_available
+  :: (IvoryExpr (ref s ('Struct "Character")),
+      IvoryExpr (ref s ('Stored Uint8)), IvoryRef ref) =>
+     ref s ('Struct "Character") -> Cond
+potions_available ref =
+  checkStored (ref ~> potions) $ \ potions_val ->
+    1 <=? potions_val
+
+check_potion_use :: Def ('[Ref s ('Struct "Character")] ':-> ())
+check_potion_use =
+  proc "check_potion_use" $ \ ref ->
+  requires (potions_available ref) $
+  body $ do
+    old_potions <- deref (ref ~> potions)
+    call_ use_potion ref
+    new_potions <- deref (ref ~> potions)
+    assert (old_potions >? new_potions)


### PR DESCRIPTION
given a program

```
  let x = 0
  if cond {
    let x = 1
  } else {
    let x = x + 1
  }
```

we want to ensure that the RHS occurrence of `x` in the else-branch refers to the `x` outside of the `if`, *not* the `x` in the then-branch.

With a single copy of the `symEnv` we would introduce a new binder for `x` in the then-branch and then see refer to that binder in the else-branch, which is bogus. So, instead we keep a copy of the env that is used to lookup the last-seen instance of a `Var`, which we can reset after running a branch.