### PR TITLE
Fixes 'Alloc.hs' example

### DIFF
--- a/ivory-examples/examples/Alloc.hs
+++ b/ivory-examples/examples/Alloc.hs
@@ -10,6 +10,7 @@ module Alloc where
 import           Ivory.Compile.C.CmdlineFrontend
 import           Ivory.Compile.C.Modules
 import           Ivory.Language
+import           Ivory.Language.Loop
 
 
 [ivory|


### PR DESCRIPTION
One of the Ivory examples wasn't compiling on my system. Looks as if 'Alloc.hs' 
needs 'upTo' and 'downTo' loop constructors, but they had not been imported
from 'Ivory.Language.Loop'.