### PR TITLE
relax `ivoryCast` constraints

### DIFF
--- a/ivory/src/Ivory/Language/Cast.hs
+++ b/ivory/src/Ivory/Language/Cast.hs
@@ -271,7 +271,7 @@ boundPred _ from = (from <=? ivoryCast (maxBound :: to))
 
 -- XXX Don't export.
 -- Type is what we're casting from.
-ivoryCast :: forall a b. (IvoryExpr a, IvoryExpr b) => a -> b
+ivoryCast :: forall a b. (IvoryVar a, IvoryExpr b) => a -> b
 ivoryCast x = wrapExpr (AST.ExpSafeCast ty (unwrapExpr x))
   where ty = ivoryType (Proxy :: Proxy a)
 


### PR DESCRIPTION
relax `ivoryCast` constraints, so it can accept non-expr argument, such as ProcPtr
