### PR TITLE
fix `ConstRef Ptr` type generation

### DIFF
--- a/ivory-backend-c/ivory-backend-c.cabal
+++ b/ivory-backend-c/ivory-backend-c.cabal
@@ -24,6 +24,7 @@ source-repository    this
 library
   exposed-modules:      Ivory.Compile.C,
                         Ivory.Compile.C.Gen,
+                        Ivory.Compile.C.Gen.Const,
                         Ivory.Compile.C.Modules,
                         Ivory.Compile.C.Prop,
                         Ivory.Compile.C.Types,

--- a/ivory-backend-c/runtime/ivory_asserts.h
+++ b/ivory-backend-c/runtime/ivory_asserts.h
@@ -54,11 +54,11 @@ extern void ivory_user_verbose_assert_hook(const char *asserttype,
 
 #else /* IVORY_TEST */
 
-#define REQUIRES(arg)
-#define ENSURES(arg)
-#define ASSUMES(arg)
-#define ASSERTS(arg)
-#define COMPILER_ASSERTS(arg)
+#define REQUIRES(arg)           (void)(arg)
+#define ENSURES(arg)            (void)(arg)
+#define ASSUMES(arg)            (void)(arg)
+#define ASSERTS(arg)            (void)(arg)
+#define COMPILER_ASSERTS(arg)   (void)(arg)
 
 #endif /* IVORY_TEST */
 

--- a/ivory-backend-c/src/Ivory/Compile/C/Gen/Const.hs
+++ b/ivory-backend-c/src/Ivory/Compile/C/Gen/Const.hs
@@ -1,0 +1,56 @@
+module Ivory.Compile.C.Gen.Const (makeTargetConst, makeTargetConstIf) where
+
+import           Data.Loc (noLoc)
+import qualified Language.C.Syntax as C
+
+makeTargetConstIf :: Bool -> C.Type -> C.Type
+makeTargetConstIf c t = if c then makeTargetConst t else t
+
+makeTargetConst :: C.Type -> C.Type
+makeTargetConst = modifyTargetQuals (C.Tconst noLoc :)
+
+modifyTargetQuals :: ([C.TypeQual] -> [C.TypeQual]) -> C.Type -> C.Type
+modifyTargetQuals f typ@(C.Type _ decl _) = case decl of
+  C.Array _ _ decl1 _ -> go decl1
+  C.Ptr _ decl1 _     -> go decl1
+  _                   -> typ
+  where
+    go decl1 = case decl1 of
+      C.DeclRoot{} ->
+        -- `typ` is rank 1 pointer, modify base
+        (modifyTypeDeclSpec . modifyDeclSpecQuals) f typ
+      C.Ptr{} ->
+        -- `typ` is rank >1 pointer, modify second pointer level
+        (modifyTypeDecl . modifyNestedDecl . modifyPtrQuals) f typ
+      _ ->
+        -- nothing to do here
+        typ
+modifyTargetQuals _ typ@C.AntiType{} = internalError typ
+
+modifyDeclSpecQuals
+  :: ([C.TypeQual] -> [C.TypeQual]) -> C.DeclSpec -> C.DeclSpec
+modifyDeclSpecQuals f declSpec = case declSpec of
+  C.DeclSpec storage quals spec loc -> C.DeclSpec storage (f quals) spec loc
+  C.AntiDeclSpec{}                  -> internalError declSpec
+  C.AntiTypeDeclSpec{}              -> internalError declSpec
+
+modifyNestedDecl :: (C.Decl -> C.Decl) -> C.Decl -> C.Decl
+modifyNestedDecl f decl0 = case decl0 of
+  C.Array quals size decl loc -> C.Array quals size (f decl) loc
+  C.Ptr quals decl loc        -> C.Ptr quals (f decl) loc
+  _                           -> decl0
+
+modifyPtrQuals :: ([C.TypeQual] -> [C.TypeQual]) -> C.Decl -> C.Decl
+modifyPtrQuals f (C.Ptr quals decl loc)  = C.Ptr (f quals) decl loc
+modifyPtrQuals _ decl                    = decl
+
+modifyTypeDecl :: (C.Decl -> C.Decl) -> C.Type -> C.Type
+modifyTypeDecl f (C.Type declSpec decl loc) = C.Type declSpec (f decl) loc
+modifyTypeDecl _ typ@C.AntiType{}           = internalError typ
+
+modifyTypeDeclSpec :: (C.DeclSpec -> C.DeclSpec) -> C.Type -> C.Type
+modifyTypeDeclSpec f (C.Type declSpec decl loc) = C.Type (f declSpec) decl loc
+modifyTypeDeclSpec _ typ@C.AntiType{}           = internalError typ
+
+internalError :: Show a => a -> b
+internalError a = error $ "internal language-c-quote data leaked: " ++ show a

--- a/ivory-examples/data/some_header.h
+++ b/ivory-examples/data/some_header.h
@@ -1,0 +1,1 @@
+#include <stdio.h> // for `putchar`

--- a/ivory-examples/data/some_other_header.h
+++ b/ivory-examples/data/some_other_header.h
@@ -1,1 +1,1 @@
-#define SOME_CONST
+#define SOME_CONST 42

--- a/ivory-examples/examples/ConstPtrRef.hs
+++ b/ivory-examples/examples/ConstPtrRef.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module ConstPtrRef where
+
+import           Control.Applicative (pure)
+import           Ivory.Language
+
+test :: Def ('[ConstRef s ('Stored (Ptr 'Global ('Stored Uint8)))] ':-> ())
+test = proc "ConstPtrRef_test" $ \refptr -> body $ do
+  ptr <- deref refptr
+  withRef ptr
+    (\ref -> do
+      val <- deref ref
+      store ref $ val + 1)
+    (pure ())
+
+cmodule :: Module
+cmodule = package "ConstPtrRef" $ incl test

--- a/ivory-examples/examples/TestExamples.hs
+++ b/ivory-examples/examples/TestExamples.hs
@@ -9,6 +9,7 @@ import qualified Bits
 import qualified ClassHierarchy
 import qualified ConcreteFile
 import qualified Cond
+import qualified ConstPtrRef
 import qualified ConstRef
 import qualified Coroutine
 import qualified Extern
@@ -54,6 +55,7 @@ modules = [ AddrOfRegression.cmodule
           , ConcreteFile.concreteIvory
           , ConcreteFile.examplesfile
           , Cond.cmodule
+          , ConstPtrRef.cmodule
           , ConstRef.cmodule
           , Coroutine.cmodule
           , Extern.cmodule

--- a/ivory-examples/examples/TestExamples.hs
+++ b/ivory-examples/examples/TestExamples.hs
@@ -70,5 +70,4 @@ modules = [ AddrOfRegression.cmodule
           , SizeOf.cmodule
           , String.cmodule
           ]
-          ++ [stdlibStringModule]
           ++ stdlibModules

--- a/ivory-examples/examples/file.ivory
+++ b/ivory-examples/examples/file.ivory
@@ -59,7 +59,7 @@ struct Foo2
 r* struct ivory_string_FooStr foostr(uint8_t i, r* struct ivory_string_FooStr s) {
   -- Allocate a new string dynamic string. Fails if the string is too large.
   alloc s0{} = $stringInit("foo");
-  if (0>i) { foostr(i-1, s0); } else {}
+  if (0 < i) { foostr(i-1, s0); } else {}
   -- Store a new string into the dynamic string data structure.
   $string_lit_store("foos", s);
   return s;

--- a/ivory-examples/ivory-examples.cabal
+++ b/ivory-examples/ivory-examples.cabal
@@ -29,6 +29,7 @@ executable ivory-c-clang-test
                       , ClassHierarchy
                       , ConcreteFile
                       , Cond
+                      , ConstPtrRef
                       , ConstRef
                       , Coroutine
                       , Extern


### PR DESCRIPTION
introduces `-Werror` to gcc, fixes #72, #101 — all these changes are connected