### PR TITLE
Only allow global nullable pointers to be stored in structures

### DIFF
--- a/ivory/src/Ivory/Language/Ref.hs
+++ b/ivory/src/Ivory/Language/Ref.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -103,5 +104,5 @@ instance IvoryStore Sint32
 instance IvoryStore Sint64
 
 -- Only allow global nullable pointers to be stored in structures.
-instance (KnownConstancy c, IvoryArea a) =>
-         IvoryStore (Pointer 'Nullable c 'Global a)
+instance (KnownConstancy c, IvoryArea a, n ~ 'Nullable, s ~ 'Global) =>
+         IvoryStore (Pointer n c s a)


### PR DESCRIPTION
Do exactly what doc says. Avoid situations like #89.