### PR TITLE
Build with GHC 8.2.2 and 8.4.2

### DIFF
--- a/ivory-backend-c/ivory-backend-c.cabal
+++ b/ivory-backend-c/ivory-backend-c.cabal
@@ -47,6 +47,9 @@ library
                         ivory,
                         ivory-opts,
                         ivory-artifact
+  if impl(ghc < 8)
+    build-depends:      semigroups
+
   hs-source-dirs:       src
   default-language:     Haskell2010
 

--- a/ivory-backend-c/src/Ivory/Compile/C/CmdlineFrontend/Options.hs
+++ b/ivory-backend-c/src/Ivory/Compile/C/CmdlineFrontend/Options.hs
@@ -2,6 +2,7 @@ module Ivory.Compile.C.CmdlineFrontend.Options where
 
 import           Prelude               ()
 import           Prelude.Compat
+import           Data.Semigroup        (Semigroup(..))
 
 import           System.Console.GetOpt (ArgDescr (..), ArgOrder (Permute),
                                         OptDescr (..), getOpt, usageInfo)
@@ -13,10 +14,13 @@ import           System.Exit           (exitFailure, exitSuccess)
 
 data OptParser opt = OptParser [String] (opt -> opt)
 
+instance Semigroup (OptParser opt) where
+  -- left-to-right composition makes the last option parsed take precedence
+  OptParser as f <> OptParser bs g = OptParser (as ++ bs) (f . g)
+
 instance Monoid (OptParser opt) where
   mempty = OptParser [] id
-  -- left-to-right composition makes the last option parsed take precedence
-  OptParser as f `mappend` OptParser bs g = OptParser (as ++ bs) (f . g)
+  mappend = (<>)
 
 -- | Option parser succeeded, use this function to transform the default
 -- options.

--- a/ivory-backend-c/src/Ivory/Compile/C/Types.hs
+++ b/ivory-backend-c/src/Ivory/Compile/C/Types.hs
@@ -8,6 +8,7 @@ import           Prelude              ()
 import           Prelude.Compat
 
 import           Data.List            (nub)
+import           Data.Semigroup       (Semigroup(..))
 
 import           Language.C.Quote.GCC
 import qualified "language-c-quote" Language.C.Syntax    as C
@@ -35,14 +36,17 @@ data CompileUnits = CompileUnits
   , headers  :: (Includes, Sources)
   } deriving Show
 
-instance Monoid CompileUnits where
-  mempty = CompileUnits mempty mempty mempty
-  (CompileUnits n0 s0 h0) `mappend` (CompileUnits n1 s1 h1) =
-    CompileUnits (n0 `mappend` n1)
-                 (go (s0 `mappend` s1))
-                 (go (h0 `mappend` h1))
+instance Semigroup CompileUnits where
+  CompileUnits n0 s0 h0 <> CompileUnits n1 s1 h1 =
+    CompileUnits (n0 <> n1)
+                 (go (s0 <> s1))
+                 (go (h0 <> h1))
     where
     go (i,s) = (nub i, nub s)
+
+instance Monoid CompileUnits where
+  mempty = CompileUnits mempty mempty mempty
+  mappend = (<>)
 
 --------------------------------------------------------------------------------
 

--- a/ivory-hw/ivory-hw.cabal
+++ b/ivory-hw/ivory-hw.cabal
@@ -11,8 +11,6 @@ copyright:           2013 Galois, Inc.
 synopsis:            Ivory hardware model (STM32F4).
 description:         Hardware model for Ivory.  Currently, the STM32F4 is supported; others may be added.
 homepage:            http://ivorylang.org
-build-type:          Simple
-cabal-version:       >= 1.10
 category:            Language
 build-type:          Simple
 cabal-version:       >=1.10

--- a/ivory-model-check/ivory-model-check.cabal
+++ b/ivory-model-check/ivory-model-check.cabal
@@ -21,6 +21,8 @@ library
                         monadLib,
                         ivory,
                         ivory-opts
+  if impl(ghc < 8)
+    build-depends:      semigroups
 
   hs-source-dirs:       src
   default-language:     Haskell2010

--- a/ivory-model-check/src/Ivory/ModelCheck/CVC4.hs
+++ b/ivory-model-check/src/Ivory/ModelCheck/CVC4.hs
@@ -8,7 +8,7 @@ module Ivory.ModelCheck.CVC4 where
 
 import Prelude ()
 import Prelude.Compat hiding (exp)
-import Data.Monoid.Compat
+import Data.Monoid.Compat ((<>))
 
 import qualified Data.ByteString.Char8 as B
 import           Data.Int

--- a/ivory-opts/src/Ivory/Opts/SanityCheck.hs
+++ b/ivory-opts/src/Ivory/Opts/SanityCheck.hs
@@ -36,7 +36,9 @@ import           MonadLib                                (Id, StateM (..),
                                                           WriterT, runId,
                                                           runStateT, runWriterT,
                                                           sets_)
-import           Text.PrettyPrint
+
+import           Data.Monoid.Compat                      ((<>))
+import           Text.PrettyPrint                        hiding ((<>))
 
 import qualified Ivory.Language.Array                    as I
 import qualified Ivory.Language.Syntax.AST               as I
@@ -178,8 +180,7 @@ showDupDefs dups =
   if null dups then return ()
     else hPutStrLn stderr $ render (vcat (map docDups dups) $$ empty)
   where
-  docDups x = text "*** WARNING"
-           <> colon
+  docDups x = (text "*** WARNING" <> colon)
           <+> quotes (text x)
           <+> text "has multiple definitions."
 

--- a/ivory-opts/src/Ivory/Opts/Utils.hs
+++ b/ivory-opts/src/Ivory/Opts/Utils.hs
@@ -6,7 +6,8 @@ module Ivory.Opts.Utils
 
 where
 
-import           Text.PrettyPrint
+import           Data.Monoid.Compat                      ((<>))
+import           Text.PrettyPrint                        hiding ((<>))
 
 import qualified Ivory.Language.Syntax.AST               as I
 import           Ivory.Language.Syntax.Concrete.Location
@@ -47,7 +48,7 @@ showModErrs doc (ModResult m errs) =
     _  ->
          hPutStrLn stderr
        $ render
-       $ text "***" <+> text "Module" <+> text m <> colon
+       $ text "***" <+> text "Module" <+> (text m <> colon)
       $$ nest 2 (vcat (map (showSymErrs doc) errs))
       $$ empty
 
@@ -57,7 +58,7 @@ showSymErrs doc (SymResult sym errs) =
   case errs of
     [] -> empty
     _  ->
-         text "***" <+> text "Symbol" <+> text sym <> colon
+         text "***" <+> text "Symbol" <+> (text sym <> colon)
       $$ nest 2 (vcat (map doc errs))
       $$ empty
 
@@ -65,4 +66,4 @@ showWithLoc :: (a -> Doc) -> Located a -> Doc
 showWithLoc sh (Located loc a) =
   case loc of
     NoLoc -> sh a
-    _     -> text (prettyPrint (pretty loc)) <> colon <+> sh a
+    _     -> text (prettyPrint (pretty loc)) <> (colon <+> sh a)

--- a/ivory/ivory.cabal
+++ b/ivory/ivory.cabal
@@ -87,7 +87,7 @@ library
                         pretty >= 1.1,
                         containers >= 0.5,
                         monadLib >= 3.7,
-                        template-haskell >= 2.8 && <2.13,
+                        template-haskell >= 2.8 && <2.14,
                         th-abstraction >=0.2.5 && <0.3,
                         filepath,
                         text,
@@ -100,3 +100,5 @@ library
   ghc-options:          -Wall
   if impl(ghc == 8.0.1)
     ghc-options:        -Wno-redundant-constraints
+  if impl(ghc < 8)
+    build-depends:      semigroups

--- a/ivory/src/Ivory/Language/Coroutine.hs
+++ b/ivory/src/Ivory/Language/Coroutine.hs
@@ -20,6 +20,7 @@ coroutine name and Ivory module.
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# OPTIONS_GHC -fsimpl-tick-factor=200 #-}
 
 module Ivory.Language.Coroutine (
   -- * Usage Notes

--- a/ivory/src/Ivory/Language/Init.hs
+++ b/ivory/src/Ivory/Language/Init.hs
@@ -10,6 +10,7 @@ module Ivory.Language.Init where
 
 import           Prelude                ()
 import           Prelude.Compat
+import           Data.Semigroup         (Semigroup(..))
 
 import           Ivory.Language.Area
 import           Ivory.Language.Array
@@ -200,9 +201,12 @@ newtype InitStruct (sym :: Symbol) = InitStruct
 
 -- Much like the C initializers, the furthest right field initializer will take
 -- precidence, and fields not mentioned will be left as zero.
+instance IvoryStruct sym => Semigroup (InitStruct sym) where
+  l <> r = InitStruct (getInitStruct l <> getInitStruct r)
+
 instance IvoryStruct sym => Monoid (InitStruct sym) where
-  mempty      = InitStruct []
-  mappend l r = InitStruct (mappend (getInitStruct l) (getInitStruct r))
+  mempty  = InitStruct []
+  mappend = (<>)
 
 istruct :: forall sym. IvoryStruct sym => [InitStruct sym] -> Init ('Struct sym)
 istruct is = Init (IStruct ty fields)

--- a/ivory/src/Ivory/Language/Module.hs
+++ b/ivory/src/Ivory/Language/Module.hs
@@ -9,6 +9,7 @@ import           Prelude                ()
 import           Prelude.Compat
 
 import           Data.List              (nub)
+import           Data.Semigroup         (Semigroup(..))
 
 import           Ivory.Language.Area    (IvoryArea)
 import           Ivory.Language.MemArea (ConstMemArea (..), MemArea (..))
@@ -43,10 +44,14 @@ instance WriterM ModuleM I.Module where
 
 type ModuleDef = ModuleM ()
 
+instance Semigroup (ModuleM ()) where
+  (<>) = (>>)
+  {-# INLINE (<>) #-}
+
 instance Monoid (ModuleM ()) where
   mempty  = return ()
-  mappend = (>>)
   {-# INLINE mempty #-}
+  mappend = (<>)
   {-# INLINE mappend #-}
 
 -- | Add an element to the public/private list, depending on visibility

--- a/ivory/src/Ivory/Language/Monad.hs
+++ b/ivory/src/Ivory/Language/Monad.hs
@@ -43,6 +43,7 @@ module Ivory.Language.Monad (
 
 import Prelude ()
 import Prelude.Compat
+import Data.Semigroup (Semigroup(..))
 
 import qualified Ivory.Language.Effects as E
 import Ivory.Language.Proxy
@@ -66,18 +67,20 @@ data CodeBlock = CodeBlock
   , blockEnsures  :: [AST.Ensure]
   } deriving (Show)
 
+instance Semigroup CodeBlock where
+  l <> r = l `seq` r `seq` CodeBlock
+    { blockStmts    = blockStmts l    <> blockStmts r
+    , blockRequires = blockRequires l <> blockRequires r
+    , blockEnsures  = blockEnsures l  <> blockEnsures r
+    }
+
 instance Monoid CodeBlock where
   mempty = CodeBlock
     { blockStmts    = []
     , blockRequires = []
     , blockEnsures  = []
     }
-  mappend l r = l `seq` r `seq` CodeBlock
-    { blockStmts    = blockStmts l    `mappend` blockStmts r
-    , blockRequires = blockRequires l `mappend` blockRequires r
-    , blockEnsures  = blockEnsures l  `mappend` blockEnsures r
-    }
-
+  mappend = (<>)
 
 -- | Run an Ivory block computation that could require any effect.
 --

--- a/ivory/src/Ivory/Language/Syntax/AST.hs
+++ b/ivory/src/Ivory/Language/Syntax/AST.hs
@@ -19,6 +19,7 @@ import           Language.Haskell.TH.Syntax              (Lift (..))
 
 import           Data.Ratio                              (denominator,
                                                           numerator)
+import           Data.Semigroup                          (Semigroup(..))
 
 -- Modules ---------------------------------------------------------------------
 
@@ -31,9 +32,12 @@ data Visible a = Visible
   , private :: [a]
   } deriving (Show, Eq, Ord)
 
+instance Semigroup (Visible a) where
+  Visible l0 l1 <> Visible m0 m1 = Visible (l0 ++ m0) (l1 ++ m1)
+
 instance Monoid (Visible a) where
-  mempty                                  = Visible [] []
-  mappend (Visible l0 l1) (Visible m0 m1) = Visible (l0 ++ m0) (l1 ++ m1)
+  mempty  = Visible [] []
+  mappend = (<>)
 
 -- | The name of a module defined in Ivory.
 type ModuleName = String
@@ -55,6 +59,19 @@ data Module = Module
   , modAreaImports :: [AreaImport]
   } deriving (Show, Eq, Ord)
 
+instance Semigroup Module where
+  l <> r = Module
+    { modName        = modName (if null (modName l) then r else l)
+    , modHeaders     = modHeaders     l <> modHeaders     r
+    , modDepends     = modDepends     l <> modDepends     r
+    , modExterns     = modExterns     l <> modExterns     r
+    , modImports     = modImports     l <> modImports     r
+    , modProcs       = modProcs       l <> modProcs       r
+    , modStructs     = modStructs     l <> modStructs     r
+    , modAreas       = modAreas       l <> modAreas       r
+    , modAreaImports = modAreaImports l <> modAreaImports r
+    }
+
 instance Monoid Module where
   mempty = Module
     { modName        = ""
@@ -67,18 +84,7 @@ instance Monoid Module where
     , modAreas       = mempty
     , modAreaImports = []
     }
-
-  mappend l r = Module
-    { modName        = modName (if null (modName l) then r else l)
-    , modHeaders     = modHeaders     l `mappend` modHeaders     r
-    , modDepends     = modDepends     l `mappend` modDepends     r
-    , modExterns     = modExterns     l `mappend` modExterns     r
-    , modImports     = modImports     l `mappend` modImports     r
-    , modProcs       = modProcs       l `mappend` modProcs       r
-    , modStructs     = modStructs     l `mappend` modStructs     r
-    , modAreas       = modAreas       l `mappend` modAreas       r
-    , modAreaImports = modAreaImports l `mappend` modAreaImports r
-    }
+  mappend = (<>)
 
 -- Imported Functions ----------------------------------------------------------
 

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,0 +1,49 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-11.17
+
+# Local packages, usually specified by relative directory name
+packages:
+  - ivory/
+  - ivory-artifact/
+  - ivory-backend-c/
+  - ivory-eval/
+  - ivory-examples/
+  - ivory-hw/
+  - ivory-model-check/
+  - ivory-opts/
+  - ivory-quickcheck/
+  - ivory-serialize/
+  - ivory-stdlib/
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+  - th-abstraction-0.2.5.0
+  - monadLib-3.7.3
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+install-ghc: true
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -1,0 +1,48 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-12.0
+
+# Local packages, usually specified by relative directory name
+packages:
+  - ivory/
+  - ivory-artifact/
+  - ivory-backend-c/
+  - ivory-eval/
+  - ivory-examples/
+  - ivory-hw/
+  - ivory-model-check/
+  - ivory-opts/
+  - ivory-quickcheck/
+  - ivory-serialize/
+  - ivory-stdlib/
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+  - monadLib-3.7.3
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+install-ghc: true
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
Mostly dancing around the Semigroup/Monoid stuff and 7.10 compatibility.

`ivory/src/Ivory/Language/Coroutine.hs` required bumping simplifier ticks for 8.4.

We currently use hackage version with 8.2, but would like to move to 8.4 when the LTS snapshot comes.