### PR TITLE
Make ivory-backend-c/runtime/ compatible with Linux kernel

### DIFF
--- a/ivory-backend-c/runtime/ivory.h
+++ b/ivory-backend-c/runtime/ivory.h
@@ -1,10 +1,14 @@
 #ifndef IVORY_H
 #define IVORY_H
 
-#include <stdint.h>
-#include <math.h>
-#include <string.h>
-#include <limits.h>
+#ifndef __KERNEL__
+  #include <stdint.h>
+  #include <math.h>
+  #include <string.h>
+  #include <limits.h>
+#else
+  #include <linux/types.h>
+#endif
 
 #include "ivory_asserts.h"
 #include "ivory_templates.h"
@@ -12,6 +16,7 @@
 #define IFOREVER true
 #define IFOREVER_INC
 
+#ifndef __KERNEL__
 // ----------------------------------------
 
 #define TYPE char
@@ -178,6 +183,7 @@ DIV_OVF_U
 #undef M
 
 // ----------------------------------------
+#endif // _KERNEL
 
 // Index type: machine-depdentent size
 typedef int idx;

--- a/ivory-backend-c/runtime/ivory_templates.h
+++ b/ivory-backend-c/runtime/ivory_templates.h
@@ -1,8 +1,10 @@
 #ifndef IVORY_TEMPLATES_H
 #define IVORY_TEMPLATES_H
 
-#include<stdbool.h>
-#include<limits.h>
+#ifndef __KERNEL__
+  #include<stdbool.h>
+  #include<limits.h>
+#endif
 
 #define CAT(X,Y) X##_##Y
 // Indirection in case X,Y defined


### PR DESCRIPTION
Required for https://github.com/HaskellEmbedded/ivory-tower-linux

Pretty harmless otherwise.