### PR TITLE
ivory-backend-c: fix argument order for logBase

### DIFF
--- a/ivory-backend-c/src/Ivory/Compile/C/Gen.hs
+++ b/ivory-backend-c/src/Ivory/Compile/C/Gen.hs
@@ -594,7 +594,7 @@ floatingUnary ty name args =
   [cexp| $id:(floatingSym ty name)($exp:(exp0 xs)) |]
 
 toLogBase :: I.Type -> [I.Expr] -> C.Exp
-toLogBase ty args = [cexp| $exp:(logC $ exp0 xs) / $exp:(logC $ exp1 xs) |]
+toLogBase ty args = [cexp| $exp:(logC $ exp1 xs) / $exp:(logC $ exp0 xs) |]
   where
   xs = mkArgs ty args
   logC e = [cexp| $id:(floatingSym ty "log")($exp:e) |]


### PR DESCRIPTION
This incorrectly generated `logBase base x = log base / log x`
instead of `logBase base x = log x / log base`