### PR TITLE
Install bootstrap alex and happy for older travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ cache:
 matrix:
   include:
     - env: GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml
-      addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-7.10.3, alex-3.1.7, happy-1.19.5], sources: [hvr-ghc]}}
     - env: GHCVER=8.0.2 STACK_YAML=stack-8.0.2.yaml
-      addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-8.0.2, alex-3.1.7, happy-1.19.5], sources: [hvr-ghc]}}
     - env: GHCVER=8.2.2 STACK_YAML=stack-8.2.2.yaml
       addons: {apt: {packages: [ghc-8.2.2], sources: [hvr-ghc]}}
     - env: GHCVER=8.4.3 STACK_YAML=stack-8.4.3.yaml
@@ -25,7 +25,7 @@ matrix:
 before_install:
  # Download and unpack the stack executable
  - mkdir -p ~/.local/bin
- - export PATH=$HOME/.local/bin:$PATH
+ - export PATH=$HOME/.local/bin:/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:$PATH
  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 # - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
  - git submodule update --init --recursive
@@ -35,6 +35,8 @@ before_install:
 
 install:
  - stack --version
+ - alex --version || echo '(no alex installed)'
+ - happy --version || echo '(no happy installed)'
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
 
 # Here starts the actual work to be performed for the package under test;


### PR DESCRIPTION
Something went wrong and master got unbuildable due to alex and happy bootstrapping issues.
This installs the build-tools to bring in the versions required by the snapshots.